### PR TITLE
Deduplicate all datasets cases

### DIFF
--- a/public/settings.json
+++ b/public/settings.json
@@ -777,7 +777,7 @@
   "fields": [
     { "id": "tags", "title": "Tags", "type": "pair" },
     { "id": "pair", "title": "Pair", "type": "string" },
-    { "id": "datasetId", "title": "Dataset ID", "type": "string" },
+    { "id": "sourceDatasetTitle", "title": "Dataset", "type": "string" },
     { "id": "patient_id", "title": "Patient ID", "type": "string" },
     { "id": "specimen_date", "title": "Specimen Date", "type": "string", "renderer": "date-range" },
     { "id": "tumor_type", "title": "Tumor Type", "type": "string" },

--- a/shared/settings.json
+++ b/shared/settings.json
@@ -743,7 +743,7 @@
   "fields": [
     { "id": "tags", "title": "Tags", "type": "pair" },
     { "id": "pair", "title": "Pair", "type": "string" },
-    { "id": "datasetId", "title": "Dataset ID", "type": "string" },
+    { "id": "sourceDatasetTitle", "title": "Dataset", "type": "string" },
     { "id": "patient_id", "title": "Patient ID", "type": "string" },
     { "id": "specimen_date", "title": "Specimen Date", "type": "string", "renderer": "date-range" },
     { "id": "tumor_type", "title": "Tumor Type", "type": "string" },

--- a/src/containers/listView/index.js
+++ b/src/containers/listView/index.js
@@ -187,10 +187,12 @@ export class ListView extends Component {
     }
 
     const options = (filterState.records || []).map((value) => {
-      const label = value
-        ? snakeCaseToHumanReadable(value)
-        : emptyLabel;
       const valueText = value == null ? "" : value.toString();
+      const label = value
+        ? filterName === "sourceDatasetTitle"
+          ? valueText
+          : snakeCaseToHumanReadable(value)
+        : emptyLabel;
       return {
         label,
         value: value || "null",

--- a/src/containers/topbar/topbar.js
+++ b/src/containers/topbar/topbar.js
@@ -13,6 +13,7 @@ import settingsActions from "../../redux/settings/actions";
 import datasetsActions from "../../redux/datasets/actions";
 import {
   ALL_DATASETS_SCOPE_VALUE,
+  distinctCaseRecords,
   getSourceCaseIdentity,
   hasBrowseScope,
   isAllDatasetsBrowseScope,
@@ -53,6 +54,15 @@ export class Topbar extends Component {
   };
 
   getAllDatasetsCaseCount = () => {
+    const cachedRecordLists = this.props.datasets.map(
+      (dataset) => this.props.manifestRecordsByDataset?.[dataset.id],
+    );
+    if (cachedRecordLists.every(Array.isArray)) {
+      return distinctCaseRecords(cachedRecordLists.flat()).filter(
+        (record) => record.visible !== false,
+      ).length;
+    }
+
     const counts = this.props.datasets.map((dataset) =>
       this.getDatasetCaseCount(dataset),
     );

--- a/src/containers/topbar/topbar.test.js
+++ b/src/containers/topbar/topbar.test.js
@@ -81,4 +81,22 @@ describe("Topbar browse scope", () => {
       "case-1",
     );
   });
+
+  it("counts all accessible datasets by distinct global cases", () => {
+    const component = makeComponent({
+      datasets: [
+        { id: "dataset-a", title: "Dataset A" },
+        { id: "dataset-b", title: "Dataset B" },
+      ],
+      manifestRecordsByDataset: {
+        "dataset-a": [
+          { datasetId: "dataset-a", caseReportId: "case-1" },
+          { datasetId: "dataset-a", caseReportId: "case-1" },
+        ],
+        "dataset-b": [{ datasetId: "dataset-b", caseReportId: "case-1" }],
+      },
+    });
+
+    expect(component.getAllDatasetsCaseCount()).toBe(1);
+  });
 });

--- a/src/helpers/browseScope.js
+++ b/src/helpers/browseScope.js
@@ -132,6 +132,54 @@ export const sourceCaseIdentityKey = (record) => {
     : null;
 };
 
+const caseIdentityKey = (record = {}) =>
+  normalizeIdentityPart(record.caseReportId ?? record.pair ?? record.id);
+
+const mergeUniqueValues = (left, right) => {
+  const values = [];
+  [left, right].flat().forEach((value) => {
+    const normalized = normalizeIdentityPart(value);
+    if (normalized && !values.includes(normalized)) values.push(normalized);
+  });
+  return values.length <= 1 ? values[0] || null : values;
+};
+
+const withDatasetTitleFallback = (record = {}) => ({
+  ...record,
+  sourceDatasetTitle: record.sourceDatasetTitle || record.datasetId,
+});
+
+export const distinctCaseRecords = (records = []) => {
+  const recordsByCase = new Map();
+
+  records.forEach((record, index) => {
+    const recordWithFallback = withDatasetTitleFallback(record);
+    const key =
+      caseIdentityKey(recordWithFallback) ||
+      sourceCaseIdentityKey(recordWithFallback) ||
+      `__row_${index}`;
+    const existing = recordsByCase.get(key);
+    if (!existing) {
+      recordsByCase.set(key, recordWithFallback);
+      return;
+    }
+
+    const preferredRecord =
+      existing.visible === false && recordWithFallback.visible !== false
+        ? recordWithFallback
+        : existing;
+    recordsByCase.set(key, {
+      ...preferredRecord,
+      sourceDatasetTitle: mergeUniqueValues(
+        existing.sourceDatasetTitle,
+        recordWithFallback.sourceDatasetTitle,
+      ),
+    });
+  });
+
+  return Array.from(recordsByCase.values());
+};
+
 export const buildCaseReportUrl = (
   currentLocation,
   sourceCase,

--- a/src/helpers/browseScope.test.js
+++ b/src/helpers/browseScope.test.js
@@ -20,6 +20,7 @@ import {
   allDatasetsBrowseScope,
   buildCaseReportUrl,
   datasetBrowseScope,
+  distinctCaseRecords,
   getBrowseScopeDatasetId,
   getSourceCaseIdentity,
   resolveBrowseDataset,
@@ -73,6 +74,53 @@ describe("browse scope", () => {
     });
 
     expect(metadata.fields).toEqual([]);
+  });
+
+  it("deduplicates global records by case ID while retaining dataset-title membership", () => {
+    expect(
+      distinctCaseRecords([
+        {
+          datasetId: "a",
+          caseReportId: "case-1",
+          sourceDatasetTitle: "Dataset A",
+        },
+        {
+          datasetId: "a",
+          caseReportId: "case-1",
+          sourceDatasetTitle: "Dataset A",
+        },
+        {
+          datasetId: "b",
+          caseReportId: "case-1",
+          sourceDatasetTitle: "Dataset B",
+        },
+        {
+          datasetId: "b",
+          caseReportId: "case-2",
+          sourceDatasetTitle: "Dataset B",
+        },
+        {
+          datasetId: "dataset-c",
+          caseReportId: "case-3",
+        },
+      ]),
+    ).toEqual([
+      expect.objectContaining({
+        datasetId: "a",
+        caseReportId: "case-1",
+        sourceDatasetTitle: ["Dataset A", "Dataset B"],
+      }),
+      expect.objectContaining({
+        datasetId: "b",
+        caseReportId: "case-2",
+        sourceDatasetTitle: "Dataset B",
+      }),
+      expect.objectContaining({
+        datasetId: "dataset-c",
+        caseReportId: "case-3",
+        sourceDatasetTitle: "dataset-c",
+      }),
+    ]);
   });
 
   it("keeps source dataset and case-report identity together", () => {

--- a/src/redux/caseReports/saga.js
+++ b/src/redux/caseReports/saga.js
@@ -26,6 +26,7 @@ import {
   searchCaseReportRecords,
 } from "../../helpers/caseReportsSearch";
 import {
+  distinctCaseRecords,
   getBrowseScopeDatasetId,
   isAllDatasetsBrowseScope,
   resolveBrowseDataset,
@@ -227,9 +228,12 @@ export function* fetchCaseReports(action = {}) {
           );
     }
 
-    const datafiles = datasets
+    const manifestRecords = datasets
       .map((dataset) => manifestRecordsByDataset[dataset.id] || [])
       .flat();
+    const datafiles = globalScope
+      ? distinctCaseRecords(manifestRecords)
+      : manifestRecords;
     const [casesWithInterpretations, interpretationsCounts] = yield call(
       loadInterpretationState,
       datasets[0],

--- a/src/redux/caseReports/saga.test.js
+++ b/src/redux/caseReports/saga.test.js
@@ -124,7 +124,7 @@ describe("static browse sagas", () => {
     }));
   });
 
-  it("loads every configured JSON manifest and preserves source identity", async () => {
+  it("loads every configured JSON manifest and returns distinct global cases", async () => {
     const dispatched = await runWorker(
       fetchCaseReports,
       {
@@ -138,13 +138,14 @@ describe("static browse sagas", () => {
     );
 
     expect(createProgressChannel).toHaveBeenCalledTimes(2);
-    expect(success.datafiles).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ datasetId: "a", caseReportId: "PAIR-1" }),
-        expect.objectContaining({ datasetId: "b", caseReportId: "PAIR-1" }),
-      ]),
-    );
-    expect(success.totalReportsCount).toBe(2);
+    expect(success.datafiles).toEqual([
+      expect.objectContaining({
+        datasetId: "a",
+        caseReportId: "PAIR-1",
+        sourceDatasetTitle: ["A", "B"],
+      }),
+    ]);
+    expect(success.totalReportsCount).toBe(1);
     expect(Object.keys(success.manifestRecordsByDataset)).toEqual(["a", "b"]);
   });
 

--- a/src/redux/populationStatistics/saga.js
+++ b/src/redux/populationStatistics/saga.js
@@ -13,6 +13,7 @@ import actions from "./actions";
 import caseReportsActions from "../caseReports/actions";
 import {
   buildAllDatasetsMetadata,
+  distinctCaseRecords,
   resolveBrowseDataset,
 } from "../../helpers/browseScope";
 import {
@@ -107,10 +108,14 @@ function* getFavoriteRecords(state, favorite) {
     );
   }
 
+  const searchableRecords = favorite.datasetId == null
+    ? distinctCaseRecords(records)
+    : records;
+
   return {
     metadata,
     records: filterCaseReportRecords(
-      records,
+      searchableRecords,
       favorite.searchFilters || {},
       metadata.fields || [],
       { casesWithInterpretations },


### PR DESCRIPTION
See #82 as main PR

patches bug: all datasets option should emit a distinct union (no duplicates)