### PR TITLE
feat: improve event editing and report presentation

### DIFF
--- a/src/components/alterationCard/index.js
+++ b/src/components/alterationCard/index.js
@@ -475,7 +475,7 @@ export class AlterationCard extends Component {
 
         <InterpretationVersionsSidepanel
           tableData={allInterpretations}
-          title="Event Versions"
+          title={t("components.interpretationVersionsSidepanel.tierHistoryTitle")}
           isOpen={showVersions}
           onOpen={this.handleRefreshVersions}
           onClose={this.handleCloseVersions}

--- a/src/components/alterationCard/index.style.js
+++ b/src/components/alterationCard/index.style.js
@@ -194,6 +194,11 @@ export default styled.div`
   .editable-field:hover .edit-btn {
     opacity: 1;
   }
+  .editable-field-actions {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 8px;
+  }
 
   /* Notes display/edit */
   .note-display {

--- a/src/components/alterationCard/index.test.js
+++ b/src/components/alterationCard/index.test.js
@@ -67,6 +67,17 @@ function findElementByClassName(node, className) {
   return null;
 }
 
+function findElementByType(node, type) {
+  if (!React.isValidElement(node)) return null;
+  if (node.type === type) return node;
+
+  for (const child of React.Children.toArray(node.props.children)) {
+    const match = findElementByType(child, type);
+    if (match) return match;
+  }
+  return null;
+}
+
 function collectText(node) {
   if (node == null || typeof node === "boolean") return [];
   if (typeof node === "string" || typeof node === "number") {
@@ -81,7 +92,10 @@ describe("AlterationCard Tier History control", () => {
   it("renders a badge button beside the variant name", () => {
     const card = new AlterationCard({
       t: (key) =>
-        key === "components.alteration-card.tier-history"
+        [
+          "components.alteration-card.tier-history",
+          "components.interpretationVersionsSidepanel.tierHistoryTitle",
+        ].includes(key)
           ? "Tier History"
           : key,
       record: {
@@ -115,6 +129,12 @@ describe("AlterationCard Tier History control", () => {
       className: "tier-history-button",
     });
     expect(collectText(rendered)).not.toContain("Switch Version");
+
+    const historySidepanel = findElementByType(
+      rendered,
+      "InterpretationVersionsSidepanel",
+    );
+    expect(historySidepanel.props.title).toBe("Tier History");
 
     historyButton.props.onClick();
     expect(card.state.showVersions).toBe(true);

--- a/src/components/editableTextBlock/index.js
+++ b/src/components/editableTextBlock/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
-import { Input, Collapse } from "antd";
-import { EditOutlined } from "@ant-design/icons";
+import { Button, Input, Collapse } from "antd";
+import { EditOutlined, SaveOutlined } from "@ant-design/icons";
 import { linkPmids } from "../../helpers/format";
 
 class EditableTextBlock extends Component {
@@ -25,11 +25,29 @@ class EditableTextBlock extends Component {
     }
   }
 
-  handleBlur = () => {
+  handleSave = () => {
+    if (!this.state.editing) return;
+
     const { onChange } = this.props;
     const { draft } = this.state;
     onChange(draft || "");
     this.setState({ editing: false });
+  };
+
+  handleBlur = () => {
+    this.handleSave();
+  };
+
+  handleKeyDown = (event) => {
+    if (event.key !== "Escape") return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    this.handleSave();
+  };
+
+  handleSaveMouseDown = (event) => {
+    event.preventDefault();
   };
 
   setEditing = (editing) => {
@@ -42,7 +60,14 @@ class EditableTextBlock extends Component {
   };
 
   render() {
-    const { title, value, useCollapse, minRows = 3, readOnly = false } = this.props;
+    const {
+      title,
+      value,
+      useCollapse,
+      minRows = 3,
+      readOnly = false,
+      saveLabel = "Save",
+    } = this.props;
     const { editing, draft } = this.state;
 
     if (editing) {
@@ -53,10 +78,23 @@ class EditableTextBlock extends Component {
             ref={this.textAreaRef}
             value={draft}
             onChange={this.handleChange}
+            onKeyDown={this.handleKeyDown}
             autoSize={{ minRows }}
             onBlur={this.handleBlur}
             style={{ marginTop: 8 }}
           />
+          <div className="editable-field-actions">
+            <Button
+              type="primary"
+              size="small"
+              icon={<SaveOutlined />}
+              onMouseDown={this.handleSaveMouseDown}
+              onClick={this.handleSave}
+              aria-label={`${saveLabel} ${title}`}
+            >
+              {saveLabel}
+            </Button>
+          </div>
         </div>
       );
     }

--- a/src/components/editableTextBlock/index.test.js
+++ b/src/components/editableTextBlock/index.test.js
@@ -1,0 +1,97 @@
+/** @jest-environment node */
+/* eslint-disable import/first */
+
+import React from "react";
+
+jest.mock("antd", () => {
+  class Input {}
+  Input.TextArea = "TextArea";
+  class Collapse {}
+  Collapse.Panel = "CollapsePanel";
+  return { Button: "Button", Collapse, Input };
+});
+jest.mock("@ant-design/icons", () => ({
+  EditOutlined: "EditOutlined",
+  SaveOutlined: "SaveOutlined",
+}));
+
+import EditableTextBlock from ".";
+
+function findElementByType(node, type) {
+  if (!React.isValidElement(node)) return null;
+  if (node.type === type) return node;
+
+  for (const child of React.Children.toArray(node.props.children)) {
+    const match = findElementByType(child, type);
+    if (match) return match;
+  }
+  return null;
+}
+
+function createEditingBlock(overrides = {}) {
+  const block = new EditableTextBlock({
+    title: "Variant Summary",
+    value: "Original",
+    onChange: jest.fn(),
+    ...overrides,
+  });
+  block.state = { editing: true, draft: "Edited value" };
+  block.setState = (update) => {
+    const nextState =
+      typeof update === "function"
+        ? update(block.state, block.props)
+        : update;
+    block.state = { ...block.state, ...nextState };
+  };
+  return block;
+}
+
+describe("EditableTextBlock save controls", () => {
+  it("saves from the visible button without blurring first", () => {
+    const block = createEditingBlock();
+    const view = block.render();
+    const saveButton = findElementByType(view, "Button");
+    const mouseDownEvent = { preventDefault: jest.fn() };
+
+    saveButton.props.onMouseDown(mouseDownEvent);
+    saveButton.props.onClick();
+
+    expect(mouseDownEvent.preventDefault).toHaveBeenCalledTimes(1);
+    expect(block.props.onChange).toHaveBeenCalledWith("Edited value");
+    expect(block.state.editing).toBe(false);
+  });
+
+  it("saves on Escape and stops the event-details modal from closing", () => {
+    const block = createEditingBlock();
+    const textArea = findElementByType(block.render(), "TextArea");
+    const event = {
+      key: "Escape",
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn(),
+    };
+
+    textArea.props.onKeyDown(event);
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+    expect(block.props.onChange).toHaveBeenCalledWith("Edited value");
+    expect(block.state.editing).toBe(false);
+  });
+
+  it("keeps ordinary textarea keys editable", () => {
+    const block = createEditingBlock();
+    const textArea = findElementByType(block.render(), "TextArea");
+    const event = {
+      key: "Enter",
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn(),
+    };
+
+    textArea.props.onKeyDown(event);
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(event.stopPropagation).not.toHaveBeenCalled();
+    expect(block.props.onChange).not.toHaveBeenCalled();
+    expect(block.state.editing).toBe(true);
+  });
+});

--- a/src/components/interpretationVersionsSidepanel/columnWidth.js
+++ b/src/components/interpretationVersionsSidepanel/columnWidth.js
@@ -1,0 +1,37 @@
+const MIN_COLUMN_WIDTH = 80;
+const APPROXIMATE_CHARACTER_WIDTH = 8;
+const HEADER_HORIZONTAL_SPACE = 24;
+const HEADER_CONTROL_SPACE = 24;
+
+export function getLabelBasedColumnWidth(label, hasHeaderControl = false) {
+  const labelWidth = String(label || "").trim().length * APPROXIMATE_CHARACTER_WIDTH;
+  const controlWidth = hasHeaderControl ? HEADER_CONTROL_SPACE : 0;
+
+  return Math.max(
+    MIN_COLUMN_WIDTH,
+    labelWidth + HEADER_HORIZONTAL_SPACE + controlWidth,
+  );
+}
+
+export function withLabelBasedColumnWidth(column, label) {
+  const hasHeaderControl = Boolean(
+    column.sorter || column.filters || column.filterDropdown,
+  );
+  const labelWidth = getLabelBasedColumnWidth(label, hasHeaderControl);
+  const configuredWidth = Number(column.width);
+  const configuredMinWidth = Number(column.minWidth);
+  const width = Math.max(
+    labelWidth,
+    Number.isFinite(configuredWidth) ? configuredWidth : 0,
+  );
+  const minWidth = Math.max(
+    width,
+    Number.isFinite(configuredMinWidth) ? configuredMinWidth : 0,
+  );
+
+  return {
+    ...column,
+    width: minWidth,
+    minWidth,
+  };
+}

--- a/src/components/interpretationVersionsSidepanel/columnWidth.test.js
+++ b/src/components/interpretationVersionsSidepanel/columnWidth.test.js
@@ -1,0 +1,29 @@
+/** @jest-environment node */
+
+import {
+  getLabelBasedColumnWidth,
+  withLabelBasedColumnWidth,
+} from "./columnWidth";
+
+describe("Tier History label-based column widths", () => {
+  it("reserves label and sorter space without relying on row data", () => {
+    expect(getLabelBasedColumnWidth("", false)).toBe(80);
+    expect(getLabelBasedColumnWidth("Dataset", true)).toBe(104);
+    expect(getLabelBasedColumnWidth("Frequency", true)).toBe(120);
+  });
+
+  it("keeps a wider configured width and raises narrower widths to the label minimum", () => {
+    expect(
+      withLabelBasedColumnWidth(
+        { key: "date", width: 120, sorter: jest.fn() },
+        "Date",
+      ),
+    ).toMatchObject({ width: 120, minWidth: 120 });
+    expect(
+      withLabelBasedColumnWidth(
+        { key: "frequency", width: 80, sorter: jest.fn() },
+        "Frequency",
+      ),
+    ).toMatchObject({ width: 120, minWidth: 120 });
+  });
+});

--- a/src/components/interpretationVersionsSidepanel/index.js
+++ b/src/components/interpretationVersionsSidepanel/index.js
@@ -3,6 +3,7 @@ import { Input, Table, Drawer } from "antd";
 import { withTranslation } from 'react-i18next';
 import { getInterpretationSourceDatasetId } from '../../helpers/interpretationHistory';
 import orderInterpretationVersionColumns from './columnOrder';
+import { withLabelBasedColumnWidth } from './columnWidth';
 
 const defaultFilterFunction = (searchTerm, data) => {
   if (!searchTerm) return data;
@@ -12,7 +13,7 @@ const defaultFilterFunction = (searchTerm, data) => {
   );
 };
 
-class InterpretationVersionsSidepanel extends Component {
+export class InterpretationVersionsSidepanel extends Component {
   state = {
     searchTerm: "",
   };
@@ -33,47 +34,88 @@ class InterpretationVersionsSidepanel extends Component {
     const { searchTerm } = this.state;
 
     const filteredData = filterFunction(searchTerm, tableData);
+    const authorLabel = this.props.t(
+      'components.interpretationVersionsSidepanel.authorColumn',
+    );
+    const dateLabel = this.props.t(
+      'components.interpretationVersionsSidepanel.dateColumn',
+    );
+    const columnTitle = (label) => () => (
+      <span style={{ whiteSpace: 'nowrap' }}>{label}</span>
+    );
+    const labeledColumn = (column, label) =>
+      withLabelBasedColumnWidth(
+        {
+          ...column,
+          title:
+            typeof column.title === 'string'
+              ? columnTitle(column.title)
+              : column.title,
+        },
+        label,
+      );
 
     const tableColumns = orderInterpretationVersionColumns([
-      {
-        title: () => <span style={{ whiteSpace: 'nowrap' }}>{this.props.t('components.interpretationVersionsSidepanel.authorColumn')}</span>,
-        dataIndex: 'authorName',
-        key: 'authorName',
-        width: 120,
-        minWidth: 120,
-        sorter: (a, b) => (a.authorName || '').localeCompare(b.authorName || ''),
-      },
-      {
-        title: () => <span style={{ whiteSpace: 'nowrap' }}>{this.props.t('components.interpretationVersionsSidepanel.dateColumn')}</span>,
-        dataIndex: 'lastModified',
-        key: 'lastModified',
-        width: 120,
-        minWidth: 120,
-        render: (date) => date ? new Date(date).toLocaleString() : '',
-        sorter: (a, b) => new Date(a.lastModified || 0) - new Date(b.lastModified || 0),
-      },
-      {
-        title: () => <span style={{ whiteSpace: 'nowrap' }}>Dataset</span>,
-        dataIndex: 'dataset',
-        key: 'dataset',
-        minWidth: 100,
-        render: (text, record) => {
-          const datasetId = getInterpretationSourceDatasetId(record);
-          const dataset = datasets.find(d => String(d.id) === String(datasetId));
-          return dataset ? dataset.title : (datasetId || '');
+      labeledColumn(
+        {
+          title: columnTitle(authorLabel),
+          dataIndex: 'authorName',
+          key: 'authorName',
+          width: 120,
+          minWidth: 120,
+          sorter: (a, b) =>
+            (a.authorName || '').localeCompare(b.authorName || ''),
         },
-        sorter: (a, b) => {
-          const datasetIdA = getInterpretationSourceDatasetId(a);
-          const datasetIdB = getInterpretationSourceDatasetId(b);
-          const datasetA = datasets.find(d => String(d.id) === String(datasetIdA))?.title || datasetIdA || '';
-          const datasetB = datasets.find(d => String(d.id) === String(datasetIdB))?.title || datasetIdB || '';
-          return datasetA.localeCompare(datasetB);
+        authorLabel,
+      ),
+      labeledColumn(
+        {
+          title: columnTitle(dateLabel),
+          dataIndex: 'lastModified',
+          key: 'lastModified',
+          width: 120,
+          minWidth: 120,
+          render: (date) => date ? new Date(date).toLocaleString() : '',
+          sorter: (a, b) =>
+            new Date(a.lastModified || 0) - new Date(b.lastModified || 0),
         },
-      },
-      ...additionalColumns.map(col => ({
-        ...col,
-        title: typeof col.title === 'string' ? () => <span style={{ whiteSpace: 'nowrap' }}>{col.title}</span> : col.title,
-      })),
+        dateLabel,
+      ),
+      labeledColumn(
+        {
+          title: columnTitle('Dataset'),
+          dataIndex: 'dataset',
+          key: 'dataset',
+          minWidth: 100,
+          render: (text, record) => {
+            const datasetId = getInterpretationSourceDatasetId(record);
+            const dataset = datasets.find(
+              d => String(d.id) === String(datasetId),
+            );
+            return dataset ? dataset.title : (datasetId || '');
+          },
+          sorter: (a, b) => {
+            const datasetIdA = getInterpretationSourceDatasetId(a);
+            const datasetIdB = getInterpretationSourceDatasetId(b);
+            const datasetA = datasets.find(
+              d => String(d.id) === String(datasetIdA),
+            )?.title || datasetIdA || '';
+            const datasetB = datasets.find(
+              d => String(d.id) === String(datasetIdB),
+            )?.title || datasetIdB || '';
+            return datasetA.localeCompare(datasetB);
+          },
+        },
+        'Dataset',
+      ),
+      ...additionalColumns.map((column) =>
+        labeledColumn(
+          column,
+          typeof column.title === 'string'
+            ? column.title
+            : String(column.key || column.dataIndex || ''),
+        ),
+      ),
     ]);
 
     return (
@@ -83,8 +125,9 @@ class InterpretationVersionsSidepanel extends Component {
         width={600}
         onClose={onClose}
         open={isOpen}
+        styles={{ body: { overflow: "hidden" } }}
       >
-        <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0 }}>
           <Input
             placeholder={this.props.t('components.interpretationVersionsSidepanel.searchPlaceholder')}
             value={searchTerm}
@@ -102,7 +145,7 @@ class InterpretationVersionsSidepanel extends Component {
               onClick: () => onSelect(record),
               style: { cursor: 'pointer' },
             })}
-            scroll={{ x: 'max-content', y: 'calc(100vh - 200px)' }}
+            scroll={{ x: 'max-content', y: 'calc(100vh - 280px)' }}
           />
         </div>
       </Drawer>

--- a/src/components/interpretationVersionsSidepanel/index.test.js
+++ b/src/components/interpretationVersionsSidepanel/index.test.js
@@ -1,0 +1,96 @@
+/** @jest-environment node */
+/* eslint-disable import/first */
+
+import React from "react";
+
+jest.mock("react-i18next", () => ({
+  withTranslation: () => (Component) => Component,
+}));
+jest.mock("antd", () => ({
+  Drawer: "Drawer",
+  Input: "Input",
+  Table: "Table",
+}));
+jest.mock("../../helpers/interpretationHistory", () => ({
+  getInterpretationSourceDatasetId: (record) => record.datasetId,
+}));
+
+import { InterpretationVersionsSidepanel } from "./index";
+
+function findElementByType(node, type) {
+  if (!React.isValidElement(node)) return null;
+  if (node.type === type) return node;
+
+  for (const child of React.Children.toArray(node.props.children)) {
+    const match = findElementByType(child, type);
+    if (match) return match;
+  }
+  return null;
+}
+
+describe("InterpretationVersionsSidepanel layout", () => {
+  it("keeps pagination visible by scrolling rows instead of the drawer body", () => {
+    const sidepanel = new InterpretationVersionsSidepanel({
+      t: (key) => key,
+      tableData: [],
+      title: "Tier History",
+      isOpen: true,
+      onClose: jest.fn(),
+      onSelect: jest.fn(),
+    });
+
+    const view = sidepanel.render();
+    const drawer = findElementByType(view, "Drawer");
+    const table = findElementByType(view, "Table");
+
+    expect(drawer.props.styles).toEqual({
+      body: { overflow: "hidden" },
+    });
+    expect(table.props.pagination).toEqual({ pageSize: 10 });
+    expect(table.props.scroll).toEqual({
+      x: "max-content",
+      y: "calc(100vh - 280px)",
+    });
+  });
+
+  it("reserves translated label widths even when the table has no rows", () => {
+    const sidepanel = new InterpretationVersionsSidepanel({
+      t: (key) =>
+        key.endsWith("dateColumn")
+          ? "Last Modified"
+          : key.endsWith("authorColumn")
+            ? "Author"
+            : key,
+      tableData: [],
+      title: "Tier History",
+      isOpen: true,
+      onClose: jest.fn(),
+      onSelect: jest.fn(),
+      additionalColumns: [
+        {
+          title: "Interpretation Source",
+          dataIndex: "source",
+          key: "source",
+        },
+      ],
+    });
+
+    const table = findElementByType(sidepanel.render(), "Table");
+    const columnsByKey = Object.fromEntries(
+      table.props.columns.map((column) => [column.key, column]),
+    );
+
+    expect(columnsByKey.lastModified).toMatchObject({
+      width: 152,
+      minWidth: 152,
+    });
+    expect(columnsByKey.dataset).toMatchObject({
+      width: 104,
+      minWidth: 104,
+    });
+    expect(columnsByKey.source).toMatchObject({
+      width: 192,
+      minWidth: 192,
+    });
+  });
+});

--- a/src/components/reportButtonsPanel/index.js
+++ b/src/components/reportButtonsPanel/index.js
@@ -159,6 +159,7 @@ class ReportButtonsPanel extends Component {
       <Wrapper>
         <Button
           className="report-view-button"
+          shape="round"
           icon={<FaFileMedical size={16} />}
           onClick={this.handlePreviewReport}
           disabled={loading}

--- a/src/components/reportButtonsPanel/index.style.js
+++ b/src/components/reportButtonsPanel/index.style.js
@@ -6,7 +6,7 @@ const Wrapper = styled.div`
 
   .report-view-button.ant-btn {
     height: 36px;
-    border-radius: 6px;
+    border-radius: 999px;
     color: #27496b;
     font-weight: 500;
   }

--- a/src/components/reportButtonsPanel/index.test.js
+++ b/src/components/reportButtonsPanel/index.test.js
@@ -106,6 +106,17 @@ describe("ReportButtonsPanel report preview", () => {
     previewReport.mockResolvedValue("<html>Report</html>");
   });
 
+  it("renders View Report as a round pill button", () => {
+    const component = createComponent();
+    const children = React.Children.toArray(component.render().props.children);
+    const viewReportButton = children.find((child) => child.type === "Button");
+
+    expect(viewReportButton.props).toMatchObject({
+      shape: "round",
+      className: "report-view-button",
+    });
+  });
+
   it("passes selected event UIDs to report preview", async () => {
     const component = createComponent({
       selectedEventUids: ["alteration-1", "alteration-2"],

--- a/src/helpers/myeloSeqDocxRenderer.js
+++ b/src/helpers/myeloSeqDocxRenderer.js
@@ -13,7 +13,7 @@ import {
   VerticalAlign,
   WidthType,
 } from "docx";
-import { datasetHasField } from "./browseScope";
+import { getMyeloSeqSpecimenFacts } from "./myeloSeqSpecimenFacts";
 
 const DOCX_MIME_TYPE =
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
@@ -131,16 +131,6 @@ function firstValue(...values) {
   return values.find(hasValue);
 }
 
-function reportHasField(report, field, allowWithoutExplicitSchema = false) {
-  const dataset = report?.dataset;
-  return (
-    !dataset ||
-    !Array.isArray(dataset.fields) ||
-    (allowWithoutExplicitSchema && !Array.isArray(dataset.schema)) ||
-    datasetHasField(dataset, field)
-  );
-}
-
 function formatNumber(value, maximumFractionDigits = 2) {
   const number = Number(value);
   if (!Number.isFinite(number)) return "";
@@ -163,45 +153,6 @@ function isFusion(finding) {
 
 function stringValue(value) {
   return hasValue(value) ? String(value) : "";
-}
-
-function buildSpecimenFacts(report) {
-  const patient = report?.patient || {};
-  const metadata = report?.metadata || {};
-  const specimenType = reportHasField(report, "specimen_type", true)
-    ? firstValue(metadata.specimen_type, metadata.specimenType)
-    : "";
-  const clinicalHistory = firstValue(
-    reportHasField(report, "clinical_history", true)
-      ? firstValue(metadata.clinical_history, metadata.clinicalHistory)
-      : "",
-    reportHasField(report, "disease")
-      ? firstValue(patient.disease, metadata.disease)
-      : "",
-    reportHasField(report, "tumor_type")
-      ? firstValue(
-          patient.tumorType,
-          metadata.tumor_type,
-          metadata.tumorType,
-          metadata.tumor,
-        )
-      : "",
-    reportHasField(report, "tumor_details")
-      ? firstValue(
-          patient.tumorDetails,
-          metadata.tumor_details,
-          metadata.tumorDetails,
-        )
-      : "",
-  );
-
-  return [
-    ["Tumor sample", patient.caseId],
-    ["Specimen Type", specimenType],
-    ["Clinical History", clinicalHistory],
-  ]
-    .filter(([, value]) => hasValue(value))
-    .map(([label, value]) => ({ label, value: String(value) }));
 }
 
 function buildResultTable(title, columnDefinitions, findings) {
@@ -313,7 +264,7 @@ function buildMyeloSeqDocxModel(report) {
   return {
     caseId: stringValue(report?.patient?.caseId),
     author: stringValue(report?.author),
-    specimenFacts: buildSpecimenFacts(report),
+    specimenFacts: getMyeloSeqSpecimenFacts(report),
     resultTables: buildResultTables(report),
     tierSections: buildTierSections(report),
     tierGuide: [...TIER_GUIDE],

--- a/src/helpers/myeloSeqDocxRenderer.test.js
+++ b/src/helpers/myeloSeqDocxRenderer.test.js
@@ -80,8 +80,8 @@ describe("MyeloSeqDocxRenderer model", () => {
 
     expect(model.specimenFacts).toEqual([
       { label: "Tumor sample", value: "CASE-001" },
-      { label: "Specimen Type", value: "Peripheral blood" },
-      { label: "Clinical History", value: "MPN" },
+      { label: "Specimen Type", value: "Bone marrow" },
+      { label: "Clinical History", value: "NA" },
     ]);
     expect(model.resultTables.map(({ title, columns }) => ({ title, columns })))
       .toEqual([
@@ -135,7 +135,7 @@ describe("MyeloSeqDocxRenderer model", () => {
     expect(JSON.stringify(model)).not.toContain("Ruxolitinib");
   });
 
-  it("honors schema visibility and the approved Clinical History fallback", () => {
+  it("honors primary-site visibility and keeps Clinical History unmapped", () => {
     const model = buildMyeloSeqDocxModel({
       ...report,
       dataset: {
@@ -158,10 +158,11 @@ describe("MyeloSeqDocxRenderer model", () => {
 
     expect(model.specimenFacts).toEqual([
       { label: "Tumor sample", value: "CASE-001" },
-      { label: "Clinical History", value: "Allowed disease" },
+      { label: "Clinical History", value: "NA" },
     ]);
     expect(model.resultTables).toEqual([]);
     expect(model.tierSections).toEqual([]);
+    expect(JSON.stringify(model)).not.toContain("Allowed disease");
     expect(JSON.stringify(model)).not.toContain("SCHEMA-OMITTED");
   });
 
@@ -174,6 +175,10 @@ describe("MyeloSeqDocxRenderer model", () => {
       ],
     });
 
+    expect(model.specimenFacts).toEqual([
+      { label: "Tumor sample", value: "CASE-EMPTY" },
+      { label: "Clinical History", value: "NA" },
+    ]);
     expect(model.resultTables).toHaveLength(1);
     expect(model.resultTables[0].columns).toEqual([
       "Gene",

--- a/src/helpers/myeloSeqHtmlRenderer.js
+++ b/src/helpers/myeloSeqHtmlRenderer.js
@@ -1,5 +1,5 @@
 import { escapeHtml } from "./format";
-import { datasetHasField } from "./browseScope";
+import { getMyeloSeqSpecimenFacts } from "./myeloSeqSpecimenFacts";
 
 function hasValue(value) {
   return value !== null && value !== undefined && String(value).trim() !== "";
@@ -7,20 +7,6 @@ function hasValue(value) {
 
 function firstValue(...values) {
   return values.find(hasValue);
-}
-
-function reportHasField(
-  report,
-  field,
-  allowWithoutExplicitSchema = false,
-) {
-  const dataset = report?.dataset;
-  return (
-    !dataset ||
-    !Array.isArray(dataset.fields) ||
-    (allowWithoutExplicitSchema && !Array.isArray(dataset.schema)) ||
-    datasetHasField(dataset, field)
-  );
 }
 
 function formatNumber(value, maximumFractionDigits = 2) {
@@ -84,44 +70,11 @@ function renderTable(title, columns, rows) {
 }
 
 function buildSpecimenSection(report) {
-  const patient = report?.patient || {};
-  const metadata = report?.metadata || {};
-  const specimenType = reportHasField(report, "specimen_type", true)
-    ? firstValue(metadata.specimen_type, metadata.specimenType)
-    : "";
-  const clinicalHistory = firstValue(
-    reportHasField(report, "clinical_history", true)
-      ? firstValue(metadata.clinical_history, metadata.clinicalHistory)
-      : "",
-    reportHasField(report, "disease")
-      ? firstValue(patient.disease, metadata.disease)
-      : "",
-    reportHasField(report, "tumor_type")
-      ? firstValue(
-          patient.tumorType,
-          metadata.tumor_type,
-          metadata.tumorType,
-          metadata.tumor,
-        )
-      : "",
-    reportHasField(report, "tumor_details")
-      ? firstValue(
-          patient.tumorDetails,
-          metadata.tumor_details,
-          metadata.tumorDetails,
-        )
-      : "",
-  );
-  const facts = [
-    ["Tumor sample", patient.caseId],
-    ["Specimen Type", specimenType],
-    ["Clinical History", clinicalHistory],
-  ];
+  const facts = getMyeloSeqSpecimenFacts(report);
 
   return `${renderSectionBar("SPECIMEN")}
   <section class="specimen-facts">${facts
-    .map(([label, value]) => renderFact(label, value))
-    .filter(Boolean)
+    .map(({ label, value }) => renderFact(label, value))
     .join("")}</section>`;
 }
 

--- a/src/helpers/myeloSeqHtmlRenderer.test.js
+++ b/src/helpers/myeloSeqHtmlRenderer.test.js
@@ -78,9 +78,11 @@ describe("MyeloSeqHtmlRenderer", () => {
     expect(result.html).toContain("SPECIMEN");
     expect(result.html).toContain("<strong>Tumor sample:</strong> CASE-001");
     expect(result.html).toContain(
-      "<strong>Specimen Type:</strong> Peripheral blood",
+      "<strong>Specimen Type:</strong> Bone marrow",
     );
-    expect(result.html).toContain("<strong>Clinical History:</strong> MPN");
+    expect(result.html).toContain("<strong>Clinical History:</strong> NA");
+    expect(result.html).not.toContain("Peripheral blood");
+    expect(result.html).not.toContain("<strong>Clinical History:</strong> MPN");
     expect(result.html).not.toContain("<strong>Tumor Type:</strong>");
     expect(result.html).not.toContain("<strong>Tumor Details:</strong>");
     expect(result.html).not.toContain("<strong>Disease:</strong>");
@@ -128,41 +130,27 @@ describe("MyeloSeqHtmlRenderer", () => {
     expect(result.html).not.toContain(">NOTES<");
   });
 
-  it.each([
-    [
-      "explicit clinical history",
-      {
-        clinical_history: "Explicit history",
-        disease: "Disease",
-        tumor_type: "Type",
-        tumor_details: "Details",
-      },
-      "Explicit history",
-    ],
-    [
-      "disease",
-      { disease: "Disease", tumor_type: "Type", tumor_details: "Details" },
-      "Disease",
-    ],
-    [
-      "tumor type",
-      { tumor_type: "Type", tumor_details: "Details" },
-      "Type",
-    ],
-    ["tumor details", { tumor_details: "Details" }, "Details"],
-  ])("uses %s as the Clinical History value", async (_source, metadata, expected) => {
+  it("always renders Clinical History as NA without mapping metadata", async () => {
     const result = await new MyeloSeqHtmlRenderer().render({
       patient: {
         caseId: "CASE-HISTORY",
-        disease: metadata.disease,
-        tumorType: metadata.tumor_type,
-        tumorDetails: metadata.tumor_details,
+        disease: "Patient disease",
+        tumorType: "Patient type",
+        tumorDetails: "Patient details",
       },
-      metadata,
+      metadata: {
+        clinical_history: "Explicit history",
+        disease: "Metadata disease",
+        tumor_type: "Metadata type",
+        tumor_details: "Metadata details",
+      },
       alterations: [],
     });
 
-    expect(result.html).toContain(`<strong>Clinical History:</strong> ${expected}`);
+    expect(result.html).toContain("<strong>Clinical History:</strong> NA");
+    expect(result.html).not.toContain("Explicit history");
+    expect(result.html).not.toContain("Patient disease");
+    expect(result.html).not.toContain("Metadata disease");
   });
 
   it("includes fixed report boilerplate without legacy embedded interpretation data", async () => {
@@ -191,7 +179,7 @@ describe("MyeloSeqHtmlRenderer", () => {
     expect(result.html).not.toContain("<th>Transcript</th>");
     expect(result.html).not.toContain("Targeted RNA Sequencing results");
     expect(result.html).toContain("<h3>Tier 2:</h3>");
-    expect(result.html).not.toContain("Clinical History");
+    expect(result.html).toContain("<strong>Clinical History:</strong> NA");
     expect(result.html).not.toContain("N/A");
   });
 
@@ -301,9 +289,8 @@ describe("MyeloSeqHtmlRenderer", () => {
       },
     });
 
-    expect(result.html).toContain(
-      "<strong>Clinical History:</strong> Allowed disease",
-    );
+    expect(result.html).toContain("<strong>Clinical History:</strong> NA");
+    expect(result.html).not.toContain("Allowed disease");
     expect(result.html).not.toContain("SCHEMA-OMITTED");
     expect(result.html).not.toContain("<strong>Specimen Type:</strong>");
   });

--- a/src/helpers/myeloSeqSpecimenFacts.js
+++ b/src/helpers/myeloSeqSpecimenFacts.js
@@ -1,0 +1,38 @@
+import { datasetHasField } from "./browseScope";
+
+function hasValue(value) {
+  return value !== null && value !== undefined && String(value).trim() !== "";
+}
+
+function firstValue(...values) {
+  return values.find(hasValue);
+}
+
+function reportHasPrimarySite(report) {
+  const dataset = report?.dataset;
+  return (
+    !dataset ||
+    !Array.isArray(dataset.fields) ||
+    datasetHasField(dataset, "primary_site")
+  );
+}
+
+export function getMyeloSeqSpecimenFacts(report) {
+  const patient = report?.patient || {};
+  const metadata = report?.metadata || {};
+  const specimenType = reportHasPrimarySite(report)
+    ? firstValue(
+        patient.primarySite,
+        metadata.primary_site,
+        metadata.primarySite,
+      )
+    : "";
+
+  return [
+    ["Tumor sample", patient.caseId],
+    ["Specimen Type", specimenType],
+    ["Clinical History", "NA"],
+  ]
+    .filter(([, value]) => hasValue(value))
+    .map(([label, value]) => ({ label, value: String(value) }));
+}

--- a/src/helpers/myeloSeqSpecimenFacts.test.js
+++ b/src/helpers/myeloSeqSpecimenFacts.test.js
@@ -1,0 +1,41 @@
+/** @jest-environment node */
+/* eslint-disable import/first */
+
+jest.mock("./browseScope", () => ({
+  datasetHasField: (dataset, fieldId) =>
+    (dataset?.fields || []).some(
+      (field) => (field.id || field.name) === fieldId,
+    ),
+}));
+
+import { getMyeloSeqSpecimenFacts } from "./myeloSeqSpecimenFacts";
+
+describe("MyeloSeq specimen facts", () => {
+  it("uses primary site for Specimen Type and never maps Clinical History", () => {
+    expect(
+      getMyeloSeqSpecimenFacts({
+        patient: { caseId: "CASE-1", primarySite: "Bone marrow" },
+        metadata: {
+          specimen_type: "Peripheral blood",
+          clinical_history: "Existing history",
+        },
+      }),
+    ).toEqual([
+      { label: "Tumor sample", value: "CASE-1" },
+      { label: "Specimen Type", value: "Bone marrow" },
+      { label: "Clinical History", value: "NA" },
+    ]);
+  });
+
+  it("omits a schema-disabled primary site but always includes NA history", () => {
+    expect(
+      getMyeloSeqSpecimenFacts({
+        dataset: {
+          fields: [{ id: "disease" }],
+        },
+        patient: { primarySite: "Schema-disabled site" },
+        metadata: { primary_site: "Schema-disabled metadata site" },
+      }),
+    ).toEqual([{ label: "Clinical History", value: "NA" }]);
+  });
+});

--- a/src/translations/en/common.json
+++ b/src/translations/en/common.json
@@ -993,6 +993,7 @@
       }
     },
     "interpretationVersionsSidepanel": {
+      "tierHistoryTitle": "Tier History",
       "searchPlaceholder": "Search interpretations...",
       "authorColumn": "Author",
       "dateColumn": "Date"


### PR DESCRIPTION
add a save button to the edit boxes in the event details modal (for comment, effect, and variant summary), esc should also save the changes instead of closing the edit box without saving 
add "Specimen Type" (corresponding to primary site) to the report above Clinical History
make the view report button a round pill like the other badge buttons instead of a rectangle
tier history sidepanel column labels overlap when empty, min width of columns should be based on labels instead of the data in the column
